### PR TITLE
Scope as parameter

### DIFF
--- a/source/js/search_form_adv.js
+++ b/source/js/search_form_adv.js
@@ -1,29 +1,31 @@
-YUI().use("node", 'anim', "event", function(Y) {
+YUI().use("node", 'anim', "event", function(Y)
+{
 
     "use strict";
 
     var body = Y.one("body");
 
-    function onSubmit(event) {
-
+    function onSubmit(event)
+    {
         event.preventDefault();
 
         var currentTarget = event.currentTarget,
             whichField1 = currentTarget.one('.group1 .field-select').get("value"),
             whichScope1 = currentTarget.one('.group1 .scope-select').get("value"),
             input1 = currentTarget.one('.group1 [type="text"]'),
-            value1 = input1.get("value");
+            value1 = input1.get("value"),
+            destinationString;
         value1 = value1.trim();
-        Y.log("whichScope1 " + whichScope1);
+        Y.log("scope is " + whichScope1);
         Y.log("value1 " + value1);
-            value1 = '"' + value1 + '"';
-        var destinationString = whichField1 + "=" + value1;
-
-        Y.log("Zounds! DestinationString is " + destinationString);
-        Y.log("Zounds! value1 is " + value1);
-        if (value1 !== "") {
+        if (value1 !== "")
+        {
+            destinationString = whichField1 + "=" + value1 + "&scope=" + whichScope1;
+            Y.log("Zounds! DestinationString is " + destinationString);
             location.href = currentTarget.get("action") + "?" + destinationString;
-        } else {
+        }
+        else
+        {
             location.href = "/aco/searchcollections/";
         }
 


### PR DESCRIPTION
Rather than using special characters around the keyword value to denote equals or contains, here we use a dedicated parameter in the URL. 